### PR TITLE
Drag event optimizations

### DIFF
--- a/src/components/EurekaCanvas.vue
+++ b/src/components/EurekaCanvas.vue
@@ -52,6 +52,7 @@
                 scaledImageWidth: 0,
                 scaledImageHeight: 0,
                 showCoordinates: false,
+                lastDragTime: 0,
                 canvasMousePosition: {
                     x: 0,
                     y: 0
@@ -191,7 +192,8 @@
             dragEvent(evt) {
                 const moved = { x: evt.offsetX - this.lastDragPosition.x, y: evt.offsetY - this.lastDragPosition.y }
                 this.lastDragPosition = { x: evt.offsetX, y: evt.offsetY }
-
+                const now = Date.now();
+                const lastDragDelta = now - this.lastDragTime;
                 this.canvasImagePos.x += moved.x
                 this.canvasImagePos.y += moved.y
 
@@ -238,7 +240,9 @@
                         this.canvasImagePos.y = this.canvasElementHeight - this.scaledImageHeight
                     }
                 }
-                if (moved.x != 0 || moved.y != 0) {
+
+                if (lastDragDelta >= 16 && (moved.x != 0 || moved.y != 0)) {
+                    this.lastDragTime = now
                     this.draw()
                 }
             },

--- a/src/components/EurekaCanvas.vue
+++ b/src/components/EurekaCanvas.vue
@@ -238,7 +238,9 @@
                         this.canvasImagePos.y = this.canvasElementHeight - this.scaledImageHeight
                     }
                 }
-                this.draw()
+                if (moved.x != 0 || moved.y != 0) {
+                    this.draw()
+                }
             },
             dragStartEvent(evt) {
                 var img = new Image();


### PR DESCRIPTION
Optimizes the drag event by limiting the amount of draw calls
redraw will only happen if the image has moved during the current drag event
and only if 16ms has elapsed since its last call

its much smoother even with ~500 elements drawn on the image