### PR TITLE
Replace quadrant system with quadtree, add hover/zoom/pan/viewport events

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -47,11 +47,13 @@ function loadPositions(): Position[] {
     icons: [],
     coordinates: { x: 1, y: 1 }
   }
-  for (let index = 0; index < 250; index++) {
+  for (let index = 0; index < 200; index++) {
+    const isCircle = index % 5 === 0
     positionsArr.push({
       ...baseObj,
       id: index,
       label: `Test-${index + 1}`,
+      drawStyle: isCircle ? 'circle' : 'default',
       coordinates: {
         x: Math.floor(Math.random() * (75 - 1 + 1)) + 1,
         y: Math.floor(Math.random() * (75 - 1 + 1)) + 1

--- a/src/components/EurekaCanvas.vue
+++ b/src/components/EurekaCanvas.vue
@@ -26,13 +26,7 @@ import {
   relativePointOnImage
 } from '../utils/coordinates'
 import { rectBounds, arcBounds, calculateTextWidthAndHeight } from '../utils/geometry'
-import {
-  createQuadrantMap,
-  resetQuadrants,
-  addBoundingBox,
-  findIntersection,
-  type QuadrantMap
-} from '../utils/spatial'
+import { Quadtree } from '../utils/spatial'
 import { useCanvasZoom } from '../composables/useCanvasZoom'
 import { useCanvasPan } from '../composables/useCanvasPan'
 import { useCanvasInput } from '../composables/useCanvasInput'
@@ -47,7 +41,7 @@ const props = defineProps<{
   positionsIdKey?: string
 }>()
 
-const emit = defineEmits(['click', 'clickedElement'])
+const emit = defineEmits(['click', 'clickedElement', 'hover', 'zoomChange', 'panChange', 'viewportChange'])
 
 const gridSizeInPixels = computed(() => props.gridSizeInPixels ?? 100)
 const coordinatesOffset = computed(() => props.coordinatesOffset ?? 0)
@@ -66,7 +60,26 @@ const canvasImagePos = reactive({ x: 0, y: 0 })
 const shouldRecalcBoundingBoxes = ref(true)
 const debugBoundingBoxes = ref(false)
 
-const positionBoundingBoxes: QuadrantMap = createQuadrantMap()
+let positionBoundingBoxes = new Quadtree({ x: 0, y: 0, width: 0, height: 0 })
+const lastHoveredId = ref<number | string | null>(null)
+
+function emitViewportChange() {
+  emit('viewportChange', {
+    bounds: {
+      x: -canvasImagePos.x / scaleMultiplier.value,
+      y: -canvasImagePos.y / scaleMultiplier.value,
+      width: canvasElementWidth.value / scaleMultiplier.value,
+      height: canvasElementHeight.value / scaleMultiplier.value,
+    },
+    zoom: zoomLevel.value
+  })
+}
+
+let viewportChangeTimer: ReturnType<typeof setTimeout> | null = null
+function debouncedViewportChange() {
+  if (viewportChangeTimer) clearTimeout(viewportChangeTimer)
+  viewportChangeTimer = setTimeout(emitViewportChange, 150)
+}
 
 const {
   zoomLevel, scaledImageWidth, scaledImageHeight,
@@ -77,14 +90,23 @@ const {
   canvasElementWidth, canvasElementHeight,
   canvasImagePos, canvasElement,
   minimumZoom, maximumZoom,
-  onAfterZoom: () => { doResetQuadrants(); draw() }
+  onAfterZoom: () => {
+    resetSpatialIndex()
+    draw()
+    emit('zoomChange', { level: zoomLevel.value, scale: scaleMultiplier.value })
+    debouncedViewportChange()
+  }
 })
 
 const { dragging, startDrag, stopDrag, dragEvent } = useCanvasPan({
   canvasImagePos,
   canvasElementWidth, canvasElementHeight,
   scaledImageWidth, scaledImageHeight,
-  onAfterPan: draw
+  onAfterPan: () => {
+    draw()
+    emit('panChange', { x: canvasImagePos.x, y: canvasImagePos.y })
+    debouncedViewportChange()
+  }
 })
 
 const { showCoordinates, mouseCoordinates, setUpListeners } = useCanvasInput({
@@ -94,11 +116,12 @@ const { showCoordinates, mouseCoordinates, setUpListeners } = useCanvasInput({
   zoomImage, dragging, startDrag, stopDrag, dragEvent,
   onResize: () => { resizeCanvas(); draw() },
   onClick: (coordinates) => emit('click', { coordinates }),
-  onClickElement: checkIntersections
+  onClickElement: checkIntersections,
+  onMouseMove: handleMouseMove
 })
 
 watch(() => props.positions, () => {
-  doResetQuadrants()
+  resetSpatialIndex()
   draw()
 })
 
@@ -123,20 +146,51 @@ function resizeCanvas() {
   canvasElement.value.height = canvasElement.value.offsetHeight
 }
 
-function doResetQuadrants() {
-  resetQuadrants(positionBoundingBoxes, scaledImageWidth.value, scaledImageHeight.value)
+function resetSpatialIndex() {
+  positionBoundingBoxes = new Quadtree({
+    x: 0, y: 0,
+    width: scaledImageWidth.value,
+    height: scaledImageHeight.value
+  })
   shouldRecalcBoundingBoxes.value = true
 }
 
 function checkIntersections(point: Coordinates) {
   if (!pointIsOnImage(point, canvasImagePos, scaledImageWidth.value, scaledImageHeight.value)) return
   const relPoint = relativePointOnImage(point, canvasImagePos)
-  const hit = findIntersection(positionBoundingBoxes, relPoint)
+  const hit = positionBoundingBoxes.queryPoint(relPoint)
   if (hit) {
     if (hit.idKey === '_index') {
       emit('clickedElement', props.positions[hit.id as number])
     } else {
       emit('clickedElement', props.positions.find(position => position[hit.idKey] === hit.id))
+    }
+  }
+}
+
+function handleMouseMove(point: Coordinates) {
+  if (!pointIsOnImage(point, canvasImagePos, scaledImageWidth.value, scaledImageHeight.value)) {
+    if (lastHoveredId.value !== null) {
+      lastHoveredId.value = null
+      emit('hover', null)
+      if (canvasElement.value) canvasElement.value.style.cursor = ''
+    }
+    return
+  }
+  const relPoint = relativePointOnImage(point, canvasImagePos)
+  const hit = positionBoundingBoxes.queryPoint(relPoint)
+  const hitId = hit ? hit.id : null
+  if (hitId !== lastHoveredId.value) {
+    lastHoveredId.value = hitId
+    if (hit) {
+      const position = hit.idKey === '_index'
+        ? props.positions[hit.id as number]
+        : props.positions.find(p => p[hit.idKey] === hit.id)
+      emit('hover', position ?? null)
+      if (canvasElement.value) canvasElement.value.style.cursor = 'pointer'
+    } else {
+      emit('hover', null)
+      if (canvasElement.value) canvasElement.value.style.cursor = ''
     }
   }
 }
@@ -153,12 +207,11 @@ function draw() {
   )
   drawPositions()
   if (debugBoundingBoxes.value) {
-    for (const key of Object.keys(positionBoundingBoxes) as (keyof QuadrantMap)[]) {
-      for (const box of positionBoundingBoxes[key].children) {
-        canvasContext.value!.strokeStyle = 'red'
-        canvasContext.value!.lineWidth = 1
-        canvasContext.value!.strokeRect(box.x, box.y, box.width, box.height)
-      }
+    const allBoxes = positionBoundingBoxes.queryArea({ x: 0, y: 0, width: scaledImageWidth.value, height: scaledImageHeight.value })
+    for (const box of allBoxes) {
+      canvasContext.value!.strokeStyle = 'red'
+      canvasContext.value!.lineWidth = 1
+      canvasContext.value!.strokeRect(box.x, box.y, box.width, box.height)
     }
   }
 }
@@ -269,7 +322,7 @@ function drawDefault(position: Position, index: number) {
 
   const fullBoundingBox = rectBounds(iconsBoundingBox, textBoundingBox)
   if (shouldRecalcBoundingBoxes.value) {
-    addBoundingBox(positionBoundingBoxes, {
+    positionBoundingBoxes.insert({
       id: positionsIdKey.value === '_index' ? index : position[positionsIdKey.value],
       idKey: positionsIdKey.value,
       x: fullBoundingBox.x - canvasImagePos.x,
@@ -319,7 +372,7 @@ function drawCircle(position: Position, index: number) {
     }
   }
   if (shouldRecalcBoundingBoxes.value) {
-    addBoundingBox(positionBoundingBoxes, {
+    positionBoundingBoxes.insert({
       id: positionsIdKey.value === '_index' ? index : position[positionsIdKey.value],
       idKey: positionsIdKey.value,
       x: arcBoundsObj.x - canvasImagePos.x,

--- a/src/composables/useCanvasInput.ts
+++ b/src/composables/useCanvasInput.ts
@@ -23,6 +23,7 @@ export interface UseCanvasInputOptions {
   onResize: () => void
   onClick: (coordinates: Coordinates) => void
   onClickElement: (point: Coordinates) => void
+  onMouseMove?: (point: Coordinates) => void
 }
 
 export function useCanvasInput(options: UseCanvasInputOptions) {
@@ -31,7 +32,7 @@ export function useCanvasInput(options: UseCanvasInputOptions) {
     scaleMultiplier, scaledImageWidth, scaledImageHeight,
     gridSizeInPixels, coordinatesOffset,
     zoomImage, dragging, startDrag, stopDrag, dragEvent,
-    onResize, onClick, onClickElement
+    onResize, onClick, onClickElement, onMouseMove
   } = options
 
   const canvasMousePosition = reactive({ x: 0, y: 0 })
@@ -110,7 +111,9 @@ export function useCanvasInput(options: UseCanvasInputOptions) {
     const point = getMousePoint(evt)
     canvasMousePosition.x = point.x
     canvasMousePosition.y = point.y
-    toggleCoordinates(pointIsOnImage(canvasMousePosition, canvasImagePos, scaledImageWidth.value, scaledImageHeight.value))
+    const onImage = pointIsOnImage(canvasMousePosition, canvasImagePos, scaledImageWidth.value, scaledImageHeight.value)
+    toggleCoordinates(onImage)
+    if (onMouseMove) onMouseMove({ x: point.x, y: point.y })
     if (dragging.value) dragEvent(evt)
     if (pinchZoom.value) pinchEvent(evt as TouchEvent)
   }

--- a/src/utils/__tests__/spatial.spec.ts
+++ b/src/utils/__tests__/spatial.spec.ts
@@ -1,138 +1,128 @@
 import { describe, it, expect } from 'vitest'
-import {
-  createQuadrantMap,
-  resetQuadrants,
-  addBoundingBox,
-  getQuadrantsForBoundingBox,
-  getPointQuadrant,
-  findIntersection
-} from '../spatial'
+import { Quadtree } from '../spatial'
 
-describe('createQuadrantMap', () => {
-  it('creates 4 empty quadrants', () => {
-    const map = createQuadrantMap()
-    expect(Object.keys(map)).toEqual(['northwest', 'northeast', 'southeast', 'southwest'])
-    for (const key of Object.keys(map) as (keyof typeof map)[]) {
-      expect(map[key].children).toEqual([])
-      expect(map[key].box).toEqual({ x: 0, y: 0, width: 0, height: 0 })
-    }
+const bounds = { x: 0, y: 0, width: 200, height: 200 }
+
+describe('Quadtree constructor', () => {
+  it('creates a tree with given bounds', () => {
+    const tree = new Quadtree(bounds)
+    expect(tree.queryPoint({ x: 100, y: 100 })).toBeUndefined()
   })
 })
 
-describe('resetQuadrants', () => {
-  it('sets quadrant boxes based on image dimensions', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 100)
-
-    expect(map.northwest.box).toEqual({ x: 0, y: 0, width: 100, height: 50 })
-    expect(map.northeast.box).toEqual({ x: 100, y: 0, width: 100, height: 50 })
-    expect(map.southeast.box).toEqual({ x: 100, y: 50, width: 100, height: 50 })
-    expect(map.southwest.box).toEqual({ x: 0, y: 50, width: 100, height: 50 })
-  })
-
-  it('clears existing children', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 100)
-    addBoundingBox(map, { id: 1, idKey: '_index', x: 10, y: 10, width: 20, height: 20 })
-    expect(map.northwest.children.length).toBe(1)
-
-    resetQuadrants(map, 200, 100)
-    expect(map.northwest.children.length).toBe(0)
-  })
-})
-
-describe('addBoundingBox', () => {
-  it('adds box to the correct quadrant', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 200)
-
-    addBoundingBox(map, { id: 1, idKey: '_index', x: 10, y: 10, width: 20, height: 20 })
-    expect(map.northwest.children.length).toBe(1)
-    expect(map.northeast.children.length).toBe(0)
-  })
-
-  it('adds box to multiple quadrants when it spans boundary', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 200)
-
-    addBoundingBox(map, { id: 1, idKey: '_index', x: 90, y: 90, width: 20, height: 20 })
-    expect(map.northwest.children.length).toBe(1)
-    expect(map.northeast.children.length).toBe(1)
-    expect(map.southeast.children.length).toBe(1)
-    expect(map.southwest.children.length).toBe(1)
-  })
-})
-
-describe('getQuadrantsForBoundingBox', () => {
-  it('returns correct quadrant for box in northwest', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 200)
-    const result = getQuadrantsForBoundingBox(map, { x: 10, y: 10, width: 20, height: 20 })
-    expect(result).toEqual(['northwest'])
-  })
-
-  it('returns correct quadrant for box in southeast', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 200)
-    const result = getQuadrantsForBoundingBox(map, { x: 110, y: 110, width: 20, height: 20 })
-    expect(result).toEqual(['southeast'])
-  })
-})
-
-describe('getPointQuadrant', () => {
-  it('returns correct quadrant for point', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 200)
-
-    expect(getPointQuadrant(map, { x: 10, y: 10 })).toBe('northwest')
-    expect(getPointQuadrant(map, { x: 150, y: 10 })).toBe('northeast')
-    expect(getPointQuadrant(map, { x: 150, y: 150 })).toBe('southeast')
-    expect(getPointQuadrant(map, { x: 10, y: 150 })).toBe('southwest')
-  })
-
-  it('returns undefined for point outside all quadrants', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 200)
-    expect(getPointQuadrant(map, { x: -10, y: -10 })).toBeUndefined()
-  })
-})
-
-describe('findIntersection', () => {
-  it('finds a hit when point is inside a bounding box', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 200)
-    addBoundingBox(map, { id: 42, idKey: 'id', x: 10, y: 10, width: 30, height: 30 })
-
-    const hit = findIntersection(map, { x: 20, y: 20 })
+describe('insert + queryPoint', () => {
+  it('finds a single inserted item on hit', () => {
+    const tree = new Quadtree(bounds)
+    tree.insert({ id: 1, idKey: '_index', x: 10, y: 10, width: 30, height: 30 })
+    const hit = tree.queryPoint({ x: 20, y: 20 })
     expect(hit).toBeDefined()
-    expect(hit!.id).toBe(42)
-    expect(hit!.idKey).toBe('id')
+    expect(hit!.id).toBe(1)
   })
 
-  it('returns undefined when point misses all boxes', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 200)
-    addBoundingBox(map, { id: 1, idKey: '_index', x: 10, y: 10, width: 30, height: 30 })
-
-    const hit = findIntersection(map, { x: 80, y: 80 })
-    expect(hit).toBeUndefined()
+  it('returns undefined on miss', () => {
+    const tree = new Quadtree(bounds)
+    tree.insert({ id: 1, idKey: '_index', x: 10, y: 10, width: 30, height: 30 })
+    expect(tree.queryPoint({ x: 80, y: 80 })).toBeUndefined()
   })
+})
 
-  it('returns topmost (last added) element when overlapping', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 200)
-    addBoundingBox(map, { id: 1, idKey: '_index', x: 10, y: 10, width: 50, height: 50 })
-    addBoundingBox(map, { id: 2, idKey: '_index', x: 20, y: 20, width: 30, height: 30 })
+describe('queryPoint bounds', () => {
+  it('returns undefined for point outside root bounds', () => {
+    const tree = new Quadtree(bounds)
+    tree.insert({ id: 1, idKey: '_index', x: 10, y: 10, width: 30, height: 30 })
+    expect(tree.queryPoint({ x: -10, y: -10 })).toBeUndefined()
+    expect(tree.queryPoint({ x: 250, y: 250 })).toBeUndefined()
+  })
+})
 
-    const hit = findIntersection(map, { x: 25, y: 25 })
+describe('queryPoint — topmost item on overlap', () => {
+  it('returns the last-inserted item when two overlap', () => {
+    const tree = new Quadtree(bounds)
+    tree.insert({ id: 1, idKey: '_index', x: 10, y: 10, width: 50, height: 50 })
+    tree.insert({ id: 2, idKey: '_index', x: 20, y: 20, width: 30, height: 30 })
+    const hit = tree.queryPoint({ x: 25, y: 25 })
     expect(hit).toBeDefined()
     expect(hit!.id).toBe(2)
   })
 
-  it('returns undefined for point outside all quadrants', () => {
-    const map = createQuadrantMap()
-    resetQuadrants(map, 200, 200)
-    const hit = findIntersection(map, { x: -10, y: -10 })
-    expect(hit).toBeUndefined()
+  it('returns first item when second does not overlap point', () => {
+    const tree = new Quadtree(bounds)
+    tree.insert({ id: 1, idKey: '_index', x: 10, y: 10, width: 50, height: 50 })
+    tree.insert({ id: 2, idKey: '_index', x: 70, y: 70, width: 20, height: 20 })
+    const hit = tree.queryPoint({ x: 20, y: 20 })
+    expect(hit).toBeDefined()
+    expect(hit!.id).toBe(1)
+  })
+})
+
+describe('insert — subdivision', () => {
+  it('still finds items after subdivision is triggered', () => {
+    const tree = new Quadtree(bounds, { maxItems: 2 })
+    tree.insert({ id: 1, idKey: '_index', x: 10, y: 10, width: 5, height: 5 })
+    tree.insert({ id: 2, idKey: '_index', x: 20, y: 10, width: 5, height: 5 })
+    tree.insert({ id: 3, idKey: '_index', x: 10, y: 20, width: 5, height: 5 })
+
+    expect(tree.queryPoint({ x: 12, y: 12 })?.id).toBe(1)
+    expect(tree.queryPoint({ x: 22, y: 12 })?.id).toBe(2)
+    expect(tree.queryPoint({ x: 12, y: 22 })?.id).toBe(3)
+  })
+})
+
+describe('large items spanning multiple children', () => {
+  it('item spanning child boundaries stays at parent and is still found', () => {
+    const tree = new Quadtree(bounds, { maxItems: 1 })
+    // This item spans all 4 quadrants (crosses both midpoints)
+    tree.insert({ id: 99, idKey: '_index', x: 90, y: 90, width: 20, height: 20 })
+    tree.insert({ id: 1, idKey: '_index', x: 10, y: 10, width: 5, height: 5 })
+    tree.insert({ id: 2, idKey: '_index', x: 150, y: 10, width: 5, height: 5 })
+
+    expect(tree.queryPoint({ x: 100, y: 100 })?.id).toBe(99)
+    expect(tree.queryPoint({ x: 12, y: 12 })?.id).toBe(1)
+  })
+})
+
+describe('queryArea', () => {
+  it('returns all items intersecting a region', () => {
+    const tree = new Quadtree(bounds)
+    tree.insert({ id: 1, idKey: '_index', x: 10, y: 10, width: 20, height: 20 })
+    tree.insert({ id: 2, idKey: '_index', x: 15, y: 15, width: 20, height: 20 })
+    tree.insert({ id: 3, idKey: '_index', x: 100, y: 100, width: 20, height: 20 })
+
+    const results = tree.queryArea({ x: 5, y: 5, width: 40, height: 40 })
+    const ids = results.map(r => r.id).sort()
+    expect(ids).toEqual([1, 2])
+  })
+
+  it('returns empty array when no items in region', () => {
+    const tree = new Quadtree(bounds)
+    tree.insert({ id: 1, idKey: '_index', x: 10, y: 10, width: 20, height: 20 })
+    const results = tree.queryArea({ x: 100, y: 100, width: 10, height: 10 })
+    expect(results).toEqual([])
+  })
+})
+
+describe('clear', () => {
+  it('empties the tree so subsequent queries return nothing', () => {
+    const tree = new Quadtree(bounds)
+    tree.insert({ id: 1, idKey: '_index', x: 10, y: 10, width: 20, height: 20 })
+    expect(tree.queryPoint({ x: 15, y: 15 })).toBeDefined()
+
+    tree.clear()
+    expect(tree.queryPoint({ x: 15, y: 15 })).toBeUndefined()
+    expect(tree.queryArea(bounds)).toEqual([])
+  })
+})
+
+describe('deep tree — max depth', () => {
+  it('does not subdivide beyond maxDepth', () => {
+    const tree = new Quadtree(bounds, { maxDepth: 1, maxItems: 1 })
+    // Insert many items in same area — should not crash or infinitely recurse
+    for (let i = 0; i < 20; i++) {
+      tree.insert({ id: i, idKey: '_index', x: 5, y: 5, width: 2, height: 2 })
+    }
+    // Last inserted should be found (topmost)
+    const hit = tree.queryPoint({ x: 6, y: 6 })
+    expect(hit).toBeDefined()
+    expect(hit!.id).toBe(19)
   })
 })

--- a/src/utils/spatial.ts
+++ b/src/utils/spatial.ts
@@ -1,97 +1,160 @@
-import type { BoundingBox, BoundingBoxEntry, Quadrant } from '../types'
+import type { BoundingBox, BoundingBoxEntry } from '../types'
 
-export type QuadrantKey = 'northwest' | 'northeast' | 'southeast' | 'southwest'
-
-export type QuadrantMap = Record<QuadrantKey, Quadrant>
-
-export function createQuadrantMap(): QuadrantMap {
-  return {
-    northwest: { box: { x: 0, y: 0, width: 0, height: 0 }, children: [] },
-    northeast: { box: { x: 0, y: 0, width: 0, height: 0 }, children: [] },
-    southeast: { box: { x: 0, y: 0, width: 0, height: 0 }, children: [] },
-    southwest: { box: { x: 0, y: 0, width: 0, height: 0 }, children: [] }
-  }
+interface QuadtreeOptions {
+  maxDepth?: number
+  maxItems?: number
 }
 
-export function resetQuadrants(
-  quadrants: QuadrantMap,
-  scaledImageWidth: number,
-  scaledImageHeight: number
-): void {
-  const halfWidth = scaledImageWidth / 2
-  const halfHeight = scaledImageHeight / 2
+export class Quadtree {
+  private bounds: BoundingBox
+  private maxDepth: number
+  private maxItems: number
+  private depth: number
+  private items: BoundingBoxEntry[]
+  private children: Quadtree[] | null
 
-  for (const [key, quadrant] of Object.entries(quadrants) as [QuadrantKey, Quadrant][]) {
-    quadrant.children.length = 0
-    quadrant.box.width = halfWidth
-    quadrant.box.height = halfHeight
-    switch (key) {
-      case 'northwest':
-        quadrant.box.x = 0
-        quadrant.box.y = 0
-        break
-      case 'northeast':
-        quadrant.box.x = halfWidth
-        quadrant.box.y = 0
-        break
-      case 'southeast':
-        quadrant.box.x = halfWidth
-        quadrant.box.y = halfHeight
-        break
-      case 'southwest':
-        quadrant.box.x = 0
-        quadrant.box.y = halfHeight
-        break
+  constructor(bounds: BoundingBox, options?: QuadtreeOptions, depth = 0) {
+    this.bounds = bounds
+    this.maxDepth = options?.maxDepth ?? 8
+    this.maxItems = options?.maxItems ?? 4
+    this.depth = depth
+    this.items = []
+    this.children = null
+  }
+
+  insert(entry: BoundingBoxEntry): void {
+    if (this.children) {
+      const child = this.getChildForEntry(entry)
+      if (child) {
+        child.insert(entry)
+      } else {
+        this.items.push(entry)
+      }
+      return
+    }
+
+    this.items.push(entry)
+
+    if (this.items.length > this.maxItems && this.depth < this.maxDepth) {
+      this.subdivide()
     }
   }
-}
 
-export function addBoundingBox(
-  quadrants: QuadrantMap,
-  boundingBox: BoundingBoxEntry
-): void {
-  const keys = getQuadrantsForBoundingBox(quadrants, boundingBox)
-  for (const key of keys) {
-    quadrants[key].children.push(boundingBox)
+  queryPoint(point: { x: number; y: number }): BoundingBoxEntry | undefined {
+    if (!this.containsPoint(this.bounds, point)) return undefined
+
+    let result: BoundingBoxEntry | undefined
+
+    // Check items at this node in reverse (topmost/last-inserted first)
+    for (let i = this.items.length - 1; i >= 0; i--) {
+      const item = this.items[i]
+      if (this.pointInBox(point, item)) {
+        result = item
+        break
+      }
+    }
+
+    // Recurse into the child containing this point
+    if (this.children) {
+      for (const child of this.children) {
+        if (this.containsPoint(child.bounds, point)) {
+          const childResult = child.queryPoint(point)
+          if (childResult) result = childResult
+          break
+        }
+      }
+    }
+
+    return result
   }
-}
 
-export function getQuadrantsForBoundingBox(
-  quadrants: QuadrantMap,
-  box: BoundingBox
-): QuadrantKey[] {
-  return (Object.keys(quadrants) as QuadrantKey[]).filter((key) => {
-    const quadBox = quadrants[key].box
-    return box.x < (quadBox.x + quadBox.width)
-      && (box.x + box.width) > quadBox.x
-      && box.y < (quadBox.y + quadBox.height)
-      && (box.y + box.height) > quadBox.y
-  })
-}
+  queryArea(area: BoundingBox): BoundingBoxEntry[] {
+    const results: BoundingBoxEntry[] = []
 
-export function getPointQuadrant(
-  quadrants: QuadrantMap,
-  point: { x: number; y: number }
-): QuadrantKey | undefined {
-  return (Object.keys(quadrants) as QuadrantKey[]).find((key) => {
-    const box = quadrants[key].box
+    if (!this.boxesIntersect(this.bounds, area)) return results
+
+    for (const item of this.items) {
+      if (this.boxesIntersect(item, area)) {
+        results.push(item)
+      }
+    }
+
+    if (this.children) {
+      for (const child of this.children) {
+        results.push(...child.queryArea(area))
+      }
+    }
+
+    return results
+  }
+
+  clear(): void {
+    this.items = []
+    this.children = null
+  }
+
+  private subdivide(): void {
+    const { x, y, width, height } = this.bounds
+    const halfW = width / 2
+    const halfH = height / 2
+    const opts = { maxDepth: this.maxDepth, maxItems: this.maxItems }
+    const nextDepth = this.depth + 1
+
+    this.children = [
+      new Quadtree({ x,           y,           width: halfW, height: halfH }, opts, nextDepth), // NW
+      new Quadtree({ x: x + halfW, y,           width: halfW, height: halfH }, opts, nextDepth), // NE
+      new Quadtree({ x,           y: y + halfH, width: halfW, height: halfH }, opts, nextDepth), // SW
+      new Quadtree({ x: x + halfW, y: y + halfH, width: halfW, height: halfH }, opts, nextDepth), // SE
+    ]
+
+    const oldItems = this.items
+    this.items = []
+
+    for (const item of oldItems) {
+      const child = this.getChildForEntry(item)
+      if (child) {
+        child.insert(item)
+      } else {
+        this.items.push(item)
+      }
+    }
+  }
+
+  private getChildForEntry(entry: BoundingBoxEntry): Quadtree | null {
+    if (!this.children) return null
+    for (const child of this.children) {
+      if (this.boxContainsBox(child.bounds, entry)) {
+        return child
+      }
+    }
+    return null
+  }
+
+  private containsPoint(box: BoundingBox, point: { x: number; y: number }): boolean {
     return point.x >= box.x
-      && point.x <= (box.x + box.width)
+      && point.x <= box.x + box.width
       && point.y >= box.y
-      && point.y <= (box.y + box.height)
-  })
-}
+      && point.y <= box.y + box.height
+  }
 
-export function findIntersection(
-  quadrants: QuadrantMap,
-  point: { x: number; y: number }
-): BoundingBoxEntry | undefined {
-  const quadrant = getPointQuadrant(quadrants, point)
-  if (!quadrant) return undefined
-  return quadrants[quadrant].children.slice().reverse().find(box =>
-    point.x >= box.x
-    && point.x <= (box.x + box.width)
-    && point.y >= box.y
-    && point.y <= (box.y + box.height)
-  )
+  private pointInBox(point: { x: number; y: number }, box: BoundingBox): boolean {
+    return point.x >= box.x
+      && point.x <= box.x + box.width
+      && point.y >= box.y
+      && point.y <= box.y + box.height
+  }
+
+  private boxesIntersect(a: BoundingBox, b: BoundingBox): boolean {
+    return a.x < b.x + b.width
+      && a.x + a.width > b.x
+      && a.y < b.y + b.height
+      && a.y + a.height > b.y
+  }
+
+  private boxContainsBox(outer: BoundingBox, inner: BoundingBox): boolean {
+    return inner.x >= outer.x
+      && inner.y >= outer.y
+      && inner.x + inner.width <= outer.x + outer.width
+      && inner.y + inner.height <= outer.y + outer.height
+  }
 }


### PR DESCRIPTION
Swap the flat 4-quadrant spatial index for a recursive quadtree that handles mixed-size objects and scales better at high position counts. Add hover, zoomChange, panChange, and viewportChange events. Cursor changes to pointer when hovering clickable markers.